### PR TITLE
 Hotfix: End of form marker for Patient Registration form

### DIFF
--- a/src/models/patient-registration-context-model.tsx
+++ b/src/models/patient-registration-context-model.tsx
@@ -93,6 +93,6 @@ export const PatientRegistrationContext: PatientRegistrationContextFormType = {
     anyAllergies: `radio(${YesNoIDKOptions.join(", ")})`,
     otherAllergies: "optional()",
     medicationAllergies: "optional()",
-    otherHealthProblems: "optional()",
+    otherHealthProblems: "optional(), end of form",
   },
 };


### PR DESCRIPTION
#43867 - End of form marker for Patient Registration (helps avoid backtracking)